### PR TITLE
Must use Upstart on CentOS 6 when using official VMware packages

### DIFF
--- a/metadata.rb
+++ b/metadata.rb
@@ -3,7 +3,7 @@ maintainer_email 'wolfe21@marshall.edu'
 license          'Apache 2.0'
 description      'Installs and configures VMWare yum repositories.'
 long_description IO.read(File.join(File.dirname(__FILE__), 'README.md'))
-version          '3.0.0'
+version          '3.0.1'
 depends          'yum'
 depends          'yum-epel'
 name             'yum-vmware-tools'

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -39,6 +39,9 @@ end
 
 node['yum']['vmware']['services'].each do |vmware_svc|
   service vmware_svc do
+    if node['platform_version'].to_i == 6 && node['yum']['vmware']['force_official']
+      provider Chef::Provider::Service::Upstart  
+    end
     action [:enable, :start]
   end
 end


### PR DESCRIPTION
When using the official VMware packages, Upstart is used to manage the vmware-tools-services service.
