### PR TITLE
Add ohai reload

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,5 +1,5 @@
 language: ruby
 rvm:
-  - 1.9.3
+  - 2.1.4
 install: bundle install --without integration
 script: bundle exec rake

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -19,6 +19,7 @@
 #
 
 package 'dmidecode'
+ohai 'reload after dmidecode install'
 
 return unless node['yum']['vmware']['enabled']
 

--- a/recipes/default.rb
+++ b/recipes/default.rb
@@ -18,7 +18,10 @@
 # limitations under the License.
 #
 
-package 'dmidecode'
+package 'dmidecode' do
+  notifies :reload, 'ohai[reload after dmidecode install]', :immediately
+end  
+
 ohai 'reload after dmidecode install'
 
 return unless node['yum']['vmware']['enabled']


### PR DESCRIPTION
I was planning on changing a whole slew of things but once I got in to the code I realized a simple Ohai reload is all that's necessary. Prior to this Ohai reload at least 2 runs of this cookbook were necessary to actually get tools installed. This is because Ohai can't get virtualization information until the run after dmidecode is installed.
